### PR TITLE
refs #6 API call to retrieve users by index

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -5,6 +5,14 @@ module Api
   #   handled as a singular resource
   #   where the user is inferred from the auth token
   class UsersController < Api::BaseController
+    rescue_from ActiveRecord::RecordNotFound, with: :missing_user
+
+    # GET /api/user/:id
+    def index
+      @user = User.find(params[:id])
+      render json: @user
+    end
+
     # GET /api/user
     def show
       render json: current_user
@@ -30,6 +38,10 @@ module Api
         :license_plate, :seniors_in_household, :adults_in_household,
         :children_in_household
       )
+    end
+
+    def missing_user
+      render json: { message: "Couldn't find User" }, status: 404
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Jets.application.routes.draw do
   namespace :api do
     resources :reservations, only: %i[index show create delete]
     resource :user, only: %i[show update]
-    get  "user/:id", to: "users#index"
+    get 'user/:id', to: 'users#index'
   end
 
   root 'jets/public#show'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Jets.application.routes.draw do
   namespace :api do
     resources :reservations, only: %i[index show create delete]
     resource :user, only: %i[show update]
+    get  "user/:id", to: "users#index"
   end
 
   root 'jets/public#show'

--- a/spec/controllers/api/users_controller_spec.rb
+++ b/spec/controllers/api/users_controller_spec.rb
@@ -40,6 +40,25 @@ describe Api::UsersController, type: :controller do
       end
     end
 
+    it 'returns the user by ID' do
+      get "/api/user/#{user.id}"
+
+      expect(response.status).to eq(200)
+      expect(JSON.parse(response.body)).to eq(user.as_json)
+    end
+
+    it 'returns 404 when user id is invalid' do
+      get '/api/user/12345'
+
+      expect(response.status).to eq(404)
+    end
+
+    it 'returns error message when user not found' do
+      get '/api/user/12345'
+
+      expect(JSON.parse(response.body)['message']).to eq('Couldn\'t find User')
+    end
+
     it 'responds with unprocessible_entity if the update fails' do
       put '/api/user', user: { phone: 'oops' }
 
@@ -49,6 +68,9 @@ describe Api::UsersController, type: :controller do
 
   context 'without authenticated requests' do
     it 'responds with unauthorized' do
+      get '/api/user/12345'
+      expect(response.status).to eq(401)
+
       get '/api/user'
       expect(response.status).to eq(401)
 


### PR DESCRIPTION
API to get user by index(:id) 
 
> curl -XGET --header 'Authorization: Bearer 1s2xeKnjBhC5vnodfYWUUA1b' 'localhost:4444/api/user/19'

{"id":19,"user_type":"guest","created_at":"2020-05-29T12:33:44.857Z","updated_at":"2020-05-29T12:34:39.296Z","first_name":"Lester","middle_name":null,"last_name":"Bellowfield","suffix":null,"gender":null,"phone":null,"email":null,"address_line_1":null,"address_line_2":null,"city":null,"state":null,"zip_code":"43201","license_plate":null,"seniors_in_household":null,"adults_in_household":2,"children_in_household":null,"permission_to_email":null,"permission_to_text":null,"date_of_birth":null,"identification_code":"qfbsqb"}
