### PR TITLE
Fix households routes for deployment

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Jets.application.routes.draw do
   namespace :api do
     resources :reservations, only: %i[index show create delete]
     resource :user, only: %i[show update]
-    resources :households
+    resources :households, only: %i[show create update delete]
   end
 
   root 'jets/public#show'


### PR DESCRIPTION
Had to exclude the `index` action from the households routes in order to deploy. The index action is not defined in the controller.