### PR TITLE
update pantrytrack api end point(beta)

### DIFF
--- a/.env.beta
+++ b/.env.beta
@@ -7,7 +7,7 @@ DB_HOST=ssm:db-host
 
 PANTRY_FINDER_API_URL=https://pantry-finder-api.beta.freshtrak.com
 
-PANTRY_TRAK_API_URL=https://secure.pantrytrak.com/core/admin/freshtrak_sync/
+PANTRY_TRAK_API_URL=https://beta.pantrytrak.com/core/admin/freshtrak_sync/
 PANTRY_TRAK_TOKEN=ssm:pantry-trak-token
 PANTRY_TRAK_SECRET=ssm:pantry-trak-secret
 

--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,2 @@
 PANTRY_FINDER_API_URL=http://localhost:8888
-PANTRY_TRAK_API_URL=https://secure.pantrytrak.com/core/admin/freshtrak_sync/
+PANTRY_TRAK_API_URL=https://beta.pantrytrak.com/core/admin/freshtrak_sync/

--- a/app/lib/pantry_trak/client.rb
+++ b/app/lib/pantry_trak/client.rb
@@ -57,19 +57,11 @@ module PantryTrak
     end
 
     def create_user_path
-      if Jets.env.production?
-        'api/create_freshtrak_user.php'
-      else
-        'api/create_freshtrak_user_beta.php'
-      end
+      'api/create_freshtrak_user.php'
     end
 
     def create_reservation_path
-      if Jets.env.production?
-        'api/create_freshtrak_reservation.php'
-      else
-        'api/create_freshtrak_reservation_beta.php'
-      end
+      'api/create_freshtrak_reservation_beta.php'
     end
 
     def handle_unsucessful_response(response)


### PR DESCRIPTION
Previous it was:
https://secure.pantrytrak.com/core/admin/freshtrak_sync/api/create_freshtrak_user_beta.php
https://secure.pantrytrak.com/core/admin/freshtrak_sync/api/create_freshtrak_reservation_beta.php

Updated in this PR to:
https://beta.pantrytrak.com/core/admin/freshtrak_sync/api/create_freshtrak_user.php
https://beta.pantrytrak.com/core/admin/freshtrak_sync/api/create_freshtrak_reservation.php